### PR TITLE
Save Componentをクリックすると、コンポーネントの画像が保存されるようにしました

### DIFF
--- a/cors.json
+++ b/cors.json
@@ -1,0 +1,6 @@
+[{
+    "origin": ["*"],
+    "method": ["GET"],
+    "maxAgeSeconds": 3600
+}]
+

--- a/src/atoms/ComponentAtom.js
+++ b/src/atoms/ComponentAtom.js
@@ -4,6 +4,8 @@ export const canvasRefAtom = atom(null);
 export const canvasItemsAtom = atom([]);
 export const stageRefAtom = atom(null);
 
+export const selectedIDAtom = atom(null);
+
 export const isPaintAtom = atom(false);
 export const paintModeAtom = atom('brush');
 export const paintWidthAtom = atom(5);

--- a/src/atoms/ComponentAtom.js
+++ b/src/atoms/ComponentAtom.js
@@ -2,6 +2,7 @@ import { atom } from "jotai";
 
 export const canvasRefAtom = atom(null);
 export const canvasItemsAtom = atom([]);
+export const stageRefAtom = atom(null);
 
 export const isPaintAtom = atom(false);
 export const paintModeAtom = atom('brush');

--- a/src/atoms/TextAtom.js
+++ b/src/atoms/TextAtom.js
@@ -10,4 +10,3 @@ export const sizeChangingAtom = atom(false);
 export const selectedTextAtom = atom(null);
 
 export const inputPositionAtom = atom(null);
-export const textComponentsAtom = atom([]);

--- a/src/components/CreateComponent/Buttons.jsx
+++ b/src/components/CreateComponent/Buttons.jsx
@@ -1,24 +1,30 @@
 import { useAtom } from "jotai";
 import React from "react";
-import { canvasItemsAtom } from "../../atoms/ComponentAtom";
+import { canvasItemsAtom, componentSizeAtom, stageRefAtom } from "../../atoms/ComponentAtom";
 import { useSave } from "../../hooks/useSave";
 
 
 const Buttons = () => {
     const [canvasItems, setCanvasItems] = useAtom(canvasItemsAtom);
+    const [stageRef] = useAtom(stageRefAtom);
     const { saveComponent } = useSave();
+
+    const handleClear = () => {
+        setCanvasItems([]);
+        stageRef.current.children[0].children = [];
+    }
 
     const handleSave = () => {
         // backEndに渡すデータ
         console.log(canvasItems);
-        saveComponent({left: 0, top: 0, width: 650, height: 650});
+        saveComponent();
     }
     return (
         <div className="flex gap-4">
             <div className="basis-1/2">
                 <a
                     className="w-full text-center inline-block rounded border border-sky-600 px-12 py-2 text-sm font-medium text-sky-600 hover:bg-sky-600 hover:text-white focus:outline-none focus:ring active:bg-sky-600"
-                    onClick={() => setCanvasItems([])}
+                    onClick={handleClear}
                 >
                     Clear All
                 </a>

--- a/src/components/CreateComponent/Buttons.jsx
+++ b/src/components/CreateComponent/Buttons.jsx
@@ -1,6 +1,6 @@
 import { useAtom } from "jotai";
 import React from "react";
-import { canvasItemsAtom, componentSizeAtom, stageRefAtom } from "../../atoms/ComponentAtom";
+import { canvasItemsAtom, stageRefAtom } from "../../atoms/ComponentAtom";
 import { useSave } from "../../hooks/useSave";
 
 
@@ -14,29 +14,32 @@ const Buttons = () => {
         stageRef.current.children[0].children = [];
     }
 
-    const handleSave = () => {
-        // backEndに渡すデータ
-        console.log(canvasItems);
+    const handleSave = (e) => {
+        if(canvasItems.length == 0) return;
+        e.target.disabled = true;
         saveComponent();
+        // Galleryに飛ばす
+        setTimeout(() => {
+            e.target.disabled = false;
+        }, 5000);
     }
     return (
         <div className="flex gap-4">
             <div className="basis-1/2">
-                <a
+                <button
                     className="w-full text-center inline-block rounded border border-sky-600 px-12 py-2 text-sm font-medium text-sky-600 hover:bg-sky-600 hover:text-white focus:outline-none focus:ring active:bg-sky-600"
                     onClick={handleClear}
                 >
                     Clear All
-                </a>
+                </button>
             </div>
             <div className="basis-1/2">
-                <a
-                    className="w-full text-center inline-block rounded border border-sky-600 bg-sky-600 px-12 py-2 text-sm font-medium text-white hover:bg-transparent hover:text-sky-600 focus:outline-none focus:ring active:text-sky-600"
-                    // href="/download"
+                <button
+                    className="w-full text-center inline-block rounded border border-sky-600 bg-sky-600 px-12 py-2 text-sm font-medium text-white hover:bg-transparent hover:text-sky-600 focus:outline-none focus:ring active:text-sky-600 disabled:bg-sky-900"
                     onClick={handleSave}
                 >
                     Save Component
-                </a>
+                </button>
             </div>
         </div>
     );

--- a/src/components/CreateComponent/Buttons.jsx
+++ b/src/components/CreateComponent/Buttons.jsx
@@ -15,7 +15,7 @@ const Buttons = () => {
     }
 
     const handleSave = (e) => {
-        if(canvasItems.length == 0) return;
+        if(canvasItems.length === 0) return;
         e.target.disabled = true;
         saveComponent();
         // Galleryに飛ばす

--- a/src/components/CreateComponent/Buttons.jsx
+++ b/src/components/CreateComponent/Buttons.jsx
@@ -1,14 +1,17 @@
 import { useAtom } from "jotai";
 import React from "react";
 import { canvasItemsAtom } from "../../atoms/ComponentAtom";
+import { useSave } from "../../hooks/useSave";
 
 
 const Buttons = () => {
     const [canvasItems, setCanvasItems] = useAtom(canvasItemsAtom);
+    const { saveComponent } = useSave();
 
-    const saveComponent = () => {
+    const handleSave = () => {
+        // backEndに渡すデータ
         console.log(canvasItems);
-        // textもitemに入れる
+        saveComponent({left: 0, top: 0, width: 650, height: 650});
     }
     return (
         <div className="flex gap-4">
@@ -24,7 +27,7 @@ const Buttons = () => {
                 <a
                     className="w-full text-center inline-block rounded border border-sky-600 bg-sky-600 px-12 py-2 text-sm font-medium text-white hover:bg-transparent hover:text-sky-600 focus:outline-none focus:ring active:text-sky-600"
                     // href="/download"
-                    onClick={saveComponent}
+                    onClick={handleSave}
                 >
                     Save Component
                 </a>

--- a/src/components/CreateComponent/CanvasArea.jsx
+++ b/src/components/CreateComponent/CanvasArea.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import Buttons from "./Buttons";
 import { Stage, Layer, Line } from "react-konva";
 import { useAtom } from "jotai";
-import { canvasItemsAtom } from "../../atoms/ComponentAtom";
+import { canvasItemsAtom, stageRefAtom } from "../../atoms/ComponentAtom";
 import ImageComponent from "../CreateMap/ImageComponent";
 import { useNewItem } from "../../hooks/useNewItem";
 import { useDrawing } from "../../hooks/useDrawing";
@@ -15,6 +15,7 @@ const CanvasArea = ({ }, canvasRef) => {
     const [isTyping, setIsTyping] = useState(false);
     const [selectedText, setSelectedText] = useAtom(selectedTextAtom);
     const [, setTextContent] = useState(null);
+    const [, setStageRefAtom] = useAtom(stageRefAtom);
     const [hidingElement, setHidingElement] = useState([]);
     const [color, setColor] = useAtom(textColorAtom);
     const [fontFamily, setFontFamily] = useAtom(fontFamilyAtom);
@@ -147,6 +148,10 @@ const CanvasArea = ({ }, canvasRef) => {
             setCanvasItems(canvasItems.filter(item => item.id !== selectedId));
         }
     }
+
+    useEffect(() => {
+        setStageRefAtom(stageRef);
+    },[])
 
     useEffect(() => {
         window.addEventListener('keydown', deleteItem)

--- a/src/components/CreateComponent/CanvasArea.jsx
+++ b/src/components/CreateComponent/CanvasArea.jsx
@@ -45,14 +45,14 @@ const CanvasArea = ({ }, canvasRef) => {
     }
 
     const handleClick = (e) => {
-        if (selectedText && stageRef.current == e.target) {
+        if (selectedText && stageRef.current === e.target) {
             cancelSelectedText();
         }
     }
 
 
     const handleTextKeyDown = (e) => {
-        if (e.key == 'Enter' && !e.shiftKey || e.key == 'Escape') {
+        if (e.key === 'Enter' && !e.shiftKey || e.key === 'Escape') {
             cancelSelectedText();
         }
     }
@@ -113,15 +113,15 @@ const CanvasArea = ({ }, canvasRef) => {
     };
 
     const handleMouseDown = (e) => {
-        if (userAction == 'drawing') {
+        if (userAction === 'drawing') {
             startDrawing(stageRef);
         }
         checkDeselect(e);
     }
 
     const handleMouseMove = (e) => {
-        if (userAction == 'drawing') {
-            let lines = stageRef.current.children[0].children.filter(child => child.attrs.id == 'line');
+        if (userAction === 'drawing') {
+            let lines = stageRef.current.children[0].children.filter(child => child.attrs.id === 'line');
             moveDrawing(e, stageRef, lines);
         }
     }
@@ -134,11 +134,11 @@ const CanvasArea = ({ }, canvasRef) => {
     }
 
     const deleteItem = (e) => {
-        if (!isDragging && e.key == 'Backspace' && selectedId) {
+        if (!isDragging && e.key === 'Backspace' && selectedId) {
             setCanvasItems(canvasItems.filter(item => item.id != selectedId));
             selectImage(null)
         }
-        if (e.key == "Backspace" && selectedText && !isTyping && !sizeChanging) {
+        if (e.key === "Backspace" && selectedText && !isTyping && !sizeChanging) {
             setCanvasItems(canvasItems.filter(item => item.id != selectedText.id))
             cancelSelectedText();
         }
@@ -174,7 +174,7 @@ const CanvasArea = ({ }, canvasRef) => {
                 >
                     <Layer>
                         {canvasItems.map((item, i) => (
-                            item.type == 'line' ?
+                            item.type === 'line' ?
                                 <Line
                                     key={item.id}
                                     id={item.type}
@@ -185,13 +185,13 @@ const CanvasArea = ({ }, canvasRef) => {
                                     lineJoin={'round'}
                                     points={item.points}
                                 />
-                                : item.type == 'text' ?
+                                : item.type === 'text' ?
                                 <TextComponent
                                     key={item.id}
                                     textProps={item}
                                     setIsTyping={setIsTyping}
                                     setHidingElement={setHidingElement}
-                                    isSelected={item == selectedText}
+                                    isSelected={item === selectedText}
                                     onChange={(newAttrs) => {
                                         const texts = canvasItems.slice();
                                         texts.splice(i, 1);

--- a/src/components/CreateComponent/CanvasArea.jsx
+++ b/src/components/CreateComponent/CanvasArea.jsx
@@ -11,7 +11,6 @@ import TextComponent from "./TextComponent";
 import { fontFamilyAtom, fontSizeAtom, fontStyleAtom, inputPositionAtom, isUnderlineAtom, selectedTextAtom, sizeChangingAtom, textColorAtom, textComponentsAtom } from "../../atoms/TextAtom";
 
 const CanvasArea = ({ }, canvasRef) => {
-    const [textComponents, setTextComponents] = useAtom(textComponentsAtom);
     const [inputPosition] = useAtom(inputPositionAtom);
     const [isTyping, setIsTyping] = useState(false);
     const [selectedText, setSelectedText] = useAtom(selectedTextAtom);
@@ -59,7 +58,7 @@ const CanvasArea = ({ }, canvasRef) => {
 
     const deleteTextComponent = (e) => {
         if (e.key == "Backspace" && selectedText && !isTyping && !sizeChanging) {
-            setTextComponents(textComponents.filter(comp => comp.id != selectedText.id));
+            setCanvasItems(canvasItems.filter(item => item.id != selectedText.id))
         }
     }
 
@@ -85,7 +84,7 @@ const CanvasArea = ({ }, canvasRef) => {
     useEffect(() => {
         if (selectedText) {
             selectedText.fontFamily = fontFamily;
-            setTextComponents([...textComponents]);
+            setCanvasItems([...canvasItems]);
         }
     }, [fontFamily])
 
@@ -104,14 +103,14 @@ const CanvasArea = ({ }, canvasRef) => {
     useEffect(() => {
         if (selectedText) {
             selectedText.fontStyle = fontStyle;
-            setTextComponents([...textComponents]);
+            setCanvasItems([...canvasItems]);
         }
     }, [fontStyle])
 
     useEffect(() => {
         if (selectedText) {
             selectedText.isUnderline = isUnderline;
-            setTextComponents([...textComponents]);
+            setCanvasItems([...canvasItems]);
         }
     }, [isUnderline])
 
@@ -179,12 +178,27 @@ const CanvasArea = ({ }, canvasRef) => {
                                 <Line
                                     key={item.id}
                                     id={item.type}
-                                    stroke={item.stroke}
-                                    strokeWidth={item.strokeWidth}
+                                    stroke={item.color}
+                                    strokeWidth={item.width}
                                     globalCompositeOperation={item.globalCompositeOperation}
-                                    lineCap={item.lineCap}
-                                    lineJoin={item.lineJoin}
+                                    lineCap={'round'}
+                                    lineJoin={'round'}
                                     points={item.points}
+                                />
+                                : item.type == 'text' ?
+                                <TextComponent
+                                    key={item.id}
+                                    textProps={item}
+                                    setIsTyping={setIsTyping}
+                                    setHidingElement={setHidingElement}
+                                    isSelected={item == selectedText}
+                                    onChange={(newAttrs) => {
+                                        const texts = canvasItems.slice();
+                                        texts.splice(i, 1);
+                                        const text = newAttrs;
+                                        texts.push(text);
+                                        setCanvasItems(texts);
+                                    }}
                                 />
                                 :
                                 <ImageComponent
@@ -203,15 +217,6 @@ const CanvasArea = ({ }, canvasRef) => {
                                         setCanvasItems(images);
                                     }}
                                 />
-                        ))}
-                        {textComponents.map(component => (
-                            <TextComponent
-                                key={component.id}
-                                textProps={component}
-                                setIsTyping={setIsTyping}
-                                setHidingElement={setHidingElement}
-                                isSelected={component == selectedText}
-                            />
                         ))}
                     </Layer>
                 </Stage>

--- a/src/components/CreateComponent/Sidebar.jsx
+++ b/src/components/CreateComponent/Sidebar.jsx
@@ -128,7 +128,7 @@ const Sidebar = () => {
                     onFocus={() => setSizeChanging(true)}
                     onBlur={() => setSizeChanging(false)}
                     onKeyDown={(e) => {
-                        if (e.key == "Enter") {
+                        if (e.key === "Enter") {
                             document.activeElement.blur();
                         }
                     }}
@@ -152,7 +152,7 @@ const Sidebar = () => {
                     />
                 </div>
                 <div className="flex justify-center">
-                    {fontStyle.indexOf('bold') == -1 ?
+                    {fontStyle.indexOf('bold') === -1 ?
                         <button className="border m-1" style={{ width: 40, height: 40 }}
                             onClick={() => setFontStyle(fontStyle + 'bold ')}
                         ><b>B</b></button>
@@ -161,7 +161,7 @@ const Sidebar = () => {
                             onClick={() => setFontStyle(fontStyle.replace('bold ', ''))}
                         ><b>B</b></button>
                     }
-                    {fontStyle.indexOf('italic') == -1 ?
+                    {fontStyle.indexOf('italic') === -1 ?
                         <button className="border m-1" style={{ width: 40, height: 40 }}
                             onClick={() => setFontStyle(fontStyle + 'italic ')}
                         ><i>I</i></button>

--- a/src/components/CreateComponent/TextComponent.jsx
+++ b/src/components/CreateComponent/TextComponent.jsx
@@ -1,11 +1,15 @@
 import { useAtom } from "jotai";
 import React, { useRef, useEffect } from "react";
 import { Text, Transformer } from "react-konva";
+import { userActionAtom } from "../../atoms/Atoms";
+import { selectedIDAtom } from "../../atoms/ComponentAtom";
 import { inputPositionAtom, selectedTextAtom } from "../../atoms/TextAtom";
 
 const TextComponent = ({ textProps, setIsTyping, setHidingElement, isSelected, onChange }) => {
     const componentRef = useRef();
     const trRef = useRef();
+    const [userAction] = useAtom(userActionAtom);
+    const [, selectImage] = useAtom(selectedIDAtom);
     const [, setInputPosition] = useAtom(inputPositionAtom);
     const [, setSelectedText] = useAtom(selectedTextAtom);
 
@@ -24,6 +28,11 @@ const TextComponent = ({ textProps, setIsTyping, setHidingElement, isSelected, o
         textProps.x = node.attrs.x;
         textProps.y = node.attrs.y;
         onChange(textProps);
+    }
+
+    const handleClick = () => {
+        selectImage(null);
+        setSelectedText(textProps)
     }
 
     const handleTransform = () => {
@@ -56,12 +65,12 @@ const TextComponent = ({ textProps, setIsTyping, setHidingElement, isSelected, o
                 width={textProps.width}
                 fontStyle={textProps.fontStyle}
                 textDecoration={textProps.isUnderline ? 'underline' : ''}
-                draggable
+                draggable={userAction == 'drawing' ? false : true}
                 fill={textProps.color}
                 onDblClick={handleDblClick}
                 onDblTap={handleDblClick}
-                onClick={() => setSelectedText(textProps)}
-                onTap={() => setSelectedText(textProps)}
+                onClick={handleClick}
+                onTap={handleClick}
                 onDragEnd={handleDragEnd}
                 onTransform={handleTransform}
                 ref={componentRef}

--- a/src/components/CreateComponent/TextComponent.jsx
+++ b/src/components/CreateComponent/TextComponent.jsx
@@ -65,7 +65,7 @@ const TextComponent = ({ textProps, setIsTyping, setHidingElement, isSelected, o
                 width={textProps.width}
                 fontStyle={textProps.fontStyle}
                 textDecoration={textProps.isUnderline ? 'underline' : ''}
-                draggable={userAction == 'drawing' ? false : true}
+                draggable={userAction === 'drawing' ? false : true}
                 fill={textProps.color}
                 onDblClick={handleDblClick}
                 onDblTap={handleDblClick}

--- a/src/components/CreateComponent/TextComponent.jsx
+++ b/src/components/CreateComponent/TextComponent.jsx
@@ -3,7 +3,7 @@ import React, { useRef, useEffect } from "react";
 import { Text, Transformer } from "react-konva";
 import { inputPositionAtom, selectedTextAtom } from "../../atoms/TextAtom";
 
-const TextComponent = ({ textProps, setIsTyping, setHidingElement, isSelected }) => {
+const TextComponent = ({ textProps, setIsTyping, setHidingElement, isSelected, onChange }) => {
     const componentRef = useRef();
     const trRef = useRef();
     const [, setInputPosition] = useAtom(inputPositionAtom);
@@ -23,6 +23,7 @@ const TextComponent = ({ textProps, setIsTyping, setHidingElement, isSelected })
         const node = componentRef.current;
         textProps.x = node.attrs.x;
         textProps.y = node.attrs.y;
+        onChange(textProps);
     }
 
     const handleTransform = () => {
@@ -34,6 +35,7 @@ const TextComponent = ({ textProps, setIsTyping, setHidingElement, isSelected })
         textProps.rotation = node.attrs.rotation;
         textProps.width = node.attrs.width;
         textProps.height = node.attrs.height;
+        onChange(textProps);
     }
 
     useEffect(() => {

--- a/src/components/CreateMap/ImageComponent.jsx
+++ b/src/components/CreateMap/ImageComponent.jsx
@@ -1,11 +1,14 @@
+import { useAtom } from 'jotai';
 import React, { useEffect, useRef } from 'react';
 import { Image, Transformer } from 'react-konva';
 import useImage from 'use-image';
+import { userActionAtom } from '../../atoms/Atoms';
 
 const ImageComponent = ({imgProps, isSelected, onSelect, onChange }) => {
     const [image] = useImage(imgProps.url);
     const componentRef = useRef();
     const trRef = useRef();
+    const [userAction] = useAtom(userActionAtom)
   
     useEffect(() => {
         if (isSelected) {
@@ -22,7 +25,7 @@ const ImageComponent = ({imgProps, isSelected, onSelect, onChange }) => {
             onTap={onSelect}
             ref={componentRef}
             {...imgProps}
-            draggable
+            draggable={userAction == 'drawing' ? false: true}
             rotation={imgProps.rotation}
             onDragEnd={(e) => {
                 onChange({

--- a/src/hooks/useDrawing.js
+++ b/src/hooks/useDrawing.js
@@ -47,7 +47,7 @@ export const useDrawing = () => {
         const lastLineRef = lines[lines.length - 1];
         var newPoints = lastLineRef.points().concat([position.x, position.y]);
         lastLineRef.points(newPoints);
-        let lineItems = canvasItems.filter(item => item.type == 'line');
+        let lineItems = canvasItems.filter(item => item.type === 'line');
         const lastLine = lineItems[lineItems.length - 1];
         lastLine.points = lastLineRef.points();
     }

--- a/src/hooks/useDrawing.js
+++ b/src/hooks/useDrawing.js
@@ -18,7 +18,7 @@ export const useDrawing = () => {
             x: null,
             y: null,
             width: paintWidth,
-            height: null,
+            height: paintWidth,
             rotation: null,
             url: null,
             text: null,

--- a/src/hooks/useDrawing.js
+++ b/src/hooks/useDrawing.js
@@ -15,15 +15,21 @@ export const useDrawing = () => {
         let newLine = {
             id: uuid(),
             type: 'line',
-            stroke: paintColor,
-            strokeWidth: paintWidth,
-            globalCompositeOperation:
-                paintMode === 'brush' ? 'source-over' : 'destination-out',
-            lineCap: 'round',
-            lineJoin: 'round',
-            // add point twice, so we have some drawings even on a simple click
-            points: [position.x, position.y, position.x, position.y],
-        };
+            x: null,
+            y: null,
+            width: paintWidth,
+            height: null,
+            rotation: null,
+            url: null,
+            text: null,
+            fontSize: null,
+            fontFamily: null,
+            color: paintColor,
+            fontStyle: null,
+            isUnderline: null,
+            globalCompositeOperation: paintMode === 'brush' ? 'source-over' : 'destination-out',
+            points: [position.x, position.y, position.x, position.y]
+        }
         setCanvasItems([...canvasItems, newLine]);
     }
 
@@ -36,7 +42,6 @@ export const useDrawing = () => {
             return;
         }
   
-        // prevent scrolling on touch devices
         e.evt.preventDefault();
         const position = stageRef.current.getPointerPosition();
         const lastLineRef = lines[lines.length - 1];

--- a/src/hooks/useNewItem.js
+++ b/src/hooks/useNewItem.js
@@ -17,15 +17,23 @@ export const useNewItem = () => {
 
     const addItem = (item, parentRef) => {
         let newItem = {
+            id: uuid(),
+            type: item.type,
             x: item.x - parentRef.current.getBoundingClientRect().left,
             y: item.y - parentRef.current.getBoundingClientRect().top,
             width: 100,
             height: 100,
             rotation: 0,
             url: item.url,
-            id: uuid(),
-            type: item.type,
-        };
+            text: null,
+            fontSize: null,
+            fontFamily: null,
+            color: null,
+            fontStyle: null,
+            isUnderline: null,
+            globalCompositeOperation: null,
+            points: null
+        }
         setCanvasItems([...canvasItems, newItem]);
     }
 

--- a/src/hooks/useNewItem.js
+++ b/src/hooks/useNewItem.js
@@ -2,11 +2,14 @@ import { useAtom } from "jotai";
 import uuid from "react-uuid";
 import { canvasItemsAtom } from "../atoms/ComponentAtom";
 import { imageComponentsAtom } from "../atoms/MapAtom";
+import { useSave } from "./useSave";
 
 
 export const useNewItem = () => {
     const [canvasItems, setCanvasItems] = useAtom(canvasItemsAtom);
     const [imageComponents, setImageComponents] = useAtom(imageComponentsAtom);
+
+
     const isValidDrop = (e, parentRef) => {
         let topOver = e.clientY < parentRef.current.getBoundingClientRect().top;
         let leftOver = e.clientX < parentRef.current.getBoundingClientRect().left;

--- a/src/hooks/useSave.js
+++ b/src/hooks/useSave.js
@@ -9,7 +9,7 @@ export const useSave = () => {
     const [stageRef] = useAtom(stageRefAtom);
 
     const addItemOnCanvas = (item) => {
-        if(item.type == 'line'){
+        if(item.type === 'line'){
             stageRef.current.children[0].add(new Konva.Line({
                 key: item.id,
                 id: item.type,
@@ -21,7 +21,7 @@ export const useSave = () => {
                 points: item.points,
             }))
         }
-        else if(item.type == 'icon' || item.type == 'image') {
+        else if(item.type === 'icon' || item.type === 'image') {
             let imgObj = new Image();
             
             imgObj.onload = function(){
@@ -38,7 +38,7 @@ export const useSave = () => {
             imgObj.src = item.url;
             
         }
-        else if(item.type == 'text') {
+        else if(item.type === 'text') {
             stageRef.current.children[0].add(new Konva.Text({
                 text: item.text,
                 x: item.x,

--- a/src/hooks/useSave.js
+++ b/src/hooks/useSave.js
@@ -1,0 +1,63 @@
+import { useAtom } from "jotai"
+import { canvasItemsAtom, stageRefAtom } from "./../atoms/ComponentAtom";
+import Konva from "konva";
+
+export const useSave = () => {
+    const [canvasItems, setCanvasItems] = useAtom(canvasItemsAtom);
+    const [stageRef] = useAtom(stageRefAtom);
+
+    const saveComponent = (size) => {
+        stageRef.current.children[0].children = [];
+        for(let item of canvasItems) {
+            if(item.type == 'line'){
+                stageRef.current.children[0].add(new Konva.Line({
+                    key: item.id,
+                    id: item.type,
+                    stroke: item.color,
+                    strokeWidth: item.width,
+                    globalCompositeOperation: item.globalCompositeOperation,
+                    lineCap: "round",
+                    lineJoin: "round",
+                    points: item.points,
+                }))
+            }
+            else if(item.type == 'icon' || item.type == 'image') {
+                let imgObj = new Image();
+                imgObj.src = item.url;
+                imgObj.crossOrigin = 'Anonymous';
+                stageRef.current.children[0].add(new Konva.Image({
+                    image: imgObj,
+                    x: item.x,
+                    y: item.y,
+                    width: item.width,
+                    height: item.height,
+                    rotation: item.rotation
+                }))
+            }
+            else if(item.type == 'text') {
+                stageRef.current.children[0].add(new Konva.Text({
+                    text: item.text,
+                    x: item.x,
+                    y: item.y,
+                    fontSize: item.fontSize,
+                    fontFamily: item.fontFamily,
+                    width: item.width,
+                    fontStyle: item.fontStyle,
+                    textDecoration: item.isUnderline ? 'underline' : '',
+                    fill: item.color,
+                }))
+            }
+        }
+        // let cx = stageRef.current.children[0].getContext('2d');
+        // console.log(cx);
+        // setTimeout(() => {
+        //     let data = stageRef.current.toDataURL();
+        //     // let data = stageRef.current.toDataURL({ left: size.left, top: size.top, width: size.width, height: size.height });
+        //     console.log(data);
+        //     setCanvasItems([]);
+        //     stageRef.current.children[0].children = [];
+        // }, 2000);
+
+    }
+    return { saveComponent }
+}

--- a/src/hooks/useSave.js
+++ b/src/hooks/useSave.js
@@ -62,9 +62,7 @@ export const useSave = () => {
             setCanvasItems([]);
             stageRef.current.children[0].children = [];
             console.log(data);
-        }, 3000);
-        
-   
+        }, 2000);
         
     }
     return { saveComponent }

--- a/src/hooks/useSave.js
+++ b/src/hooks/useSave.js
@@ -6,25 +6,23 @@ export const useSave = () => {
     const [canvasItems, setCanvasItems] = useAtom(canvasItemsAtom);
     const [stageRef] = useAtom(stageRefAtom);
 
-    const saveComponent = (size) => {
-        stageRef.current.children[0].children = [];
-        for(let item of canvasItems) {
-            if(item.type == 'line'){
-                stageRef.current.children[0].add(new Konva.Line({
-                    key: item.id,
-                    id: item.type,
-                    stroke: item.color,
-                    strokeWidth: item.width,
-                    globalCompositeOperation: item.globalCompositeOperation,
-                    lineCap: "round",
-                    lineJoin: "round",
-                    points: item.points,
-                }))
-            }
-            else if(item.type == 'icon' || item.type == 'image') {
-                let imgObj = new Image();
-                imgObj.src = item.url;
-                imgObj.crossOrigin = 'Anonymous';
+    const addItemOnCanvas = (item) => {
+        if(item.type == 'line'){
+            stageRef.current.children[0].add(new Konva.Line({
+                key: item.id,
+                id: item.type,
+                stroke: item.color,
+                strokeWidth: item.width,
+                globalCompositeOperation: item.globalCompositeOperation,
+                lineCap: "round",
+                lineJoin: "round",
+                points: item.points,
+            }))
+        }
+        else if(item.type == 'icon' || item.type == 'image') {
+            let imgObj = new Image();
+            
+            imgObj.onload = function(){
                 stageRef.current.children[0].add(new Konva.Image({
                     image: imgObj,
                     x: item.x,
@@ -34,30 +32,49 @@ export const useSave = () => {
                     rotation: item.rotation
                 }))
             }
-            else if(item.type == 'text') {
-                stageRef.current.children[0].add(new Konva.Text({
-                    text: item.text,
-                    x: item.x,
-                    y: item.y,
-                    fontSize: item.fontSize,
-                    fontFamily: item.fontFamily,
-                    width: item.width,
-                    fontStyle: item.fontStyle,
-                    textDecoration: item.isUnderline ? 'underline' : '',
-                    fill: item.color,
-                }))
-            }
+            imgObj.crossOrigin = "Anonymous";
+            imgObj.src = item.url;
+            
         }
-        // let cx = stageRef.current.children[0].getContext('2d');
-        // console.log(cx);
-        // setTimeout(() => {
-        //     let data = stageRef.current.toDataURL();
-        //     // let data = stageRef.current.toDataURL({ left: size.left, top: size.top, width: size.width, height: size.height });
-        //     console.log(data);
-        //     setCanvasItems([]);
-        //     stageRef.current.children[0].children = [];
-        // }, 2000);
+        else if(item.type == 'text') {
+            stageRef.current.children[0].add(new Konva.Text({
+                text: item.text,
+                x: item.x,
+                y: item.y,
+                fontSize: item.fontSize,
+                fontFamily: item.fontFamily,
+                width: item.width,
+                fontStyle: item.fontStyle,
+                textDecoration: item.isUnderline ? 'underline' : '',
+                fill: item.color,
+            }))
+        }
+    }
 
+    const saveComponent = () => {
+        let componentSize = { left: 650, right: 0, top: 650, bottom: 0 };
+        stageRef.current.children[0].children = [];
+        for(let item of canvasItems) {
+            addItemOnCanvas(item);
+            if(item.type != 'line'){
+                componentSize = {
+                    left: Math.min(componentSize.left, item.x),
+                    right: Math.max(componentSize.right, item.x + item.width),
+                    top: Math.min(componentSize.top, item.y),
+                    bottom: Math.max(componentSize.bottom, item.y + item.height),
+                }
+            }
+            
+        }
+    
+        // let data = stageRef.current.toDataURL();
+        // setCanvasItems([]);
+        // stageRef.current.children[0].children = [];
+        // console.log(data);
+        // console.log(componentSize);
+        console.log(stageRef.current)
+   
+        
     }
     return { saveComponent }
 }

--- a/src/hooks/useSave.js
+++ b/src/hooks/useSave.js
@@ -52,27 +52,18 @@ export const useSave = () => {
     }
 
     const saveComponent = () => {
-        let componentSize = { left: 650, right: 0, top: 650, bottom: 0 };
         stageRef.current.children[0].children = [];
         for(let item of canvasItems) {
-            addItemOnCanvas(item);
-            if(item.type != 'line'){
-                componentSize = {
-                    left: Math.min(componentSize.left, item.x),
-                    right: Math.max(componentSize.right, item.x + item.width),
-                    top: Math.min(componentSize.top, item.y),
-                    bottom: Math.max(componentSize.bottom, item.y + item.height),
-                }
-            }
-            
+            addItemOnCanvas(item);   
         }
-    
-        // let data = stageRef.current.toDataURL();
-        // setCanvasItems([]);
-        // stageRef.current.children[0].children = [];
-        // console.log(data);
-        // console.log(componentSize);
-        console.log(stageRef.current)
+        
+        setTimeout(() => {
+            let data = stageRef.current.toDataURL();
+            setCanvasItems([]);
+            stageRef.current.children[0].children = [];
+            console.log(data);
+        }, 3000);
+        
    
         
     }

--- a/src/hooks/useSave.js
+++ b/src/hooks/useSave.js
@@ -1,6 +1,8 @@
 import { useAtom } from "jotai"
 import { canvasItemsAtom, stageRefAtom } from "./../atoms/ComponentAtom";
 import Konva from "konva";
+import uuid from "react-uuid";
+import { auth } from "../client/firebase";
 
 export const useSave = () => {
     const [canvasItems, setCanvasItems] = useAtom(canvasItemsAtom);
@@ -59,11 +61,27 @@ export const useSave = () => {
         
         setTimeout(() => {
             let data = stageRef.current.toDataURL();
+            console.log(data);
+            saveNewMap(data);
             setCanvasItems([]);
             stageRef.current.children[0].children = [];
-            console.log(data);
         }, 2000);
         
+    }
+
+    const saveNewMap = (mapUrl) => {
+        // 現在のComponentをMapにした場合
+        let newMap = 
+        {
+            mapID: uuid(),
+            mapTitle: "",
+            author: auth.currentUser.uid,
+            url: mapUrl,
+            mapItems: canvasItems,
+            backgroundColor: "white",
+            createdAt: Date()
+        }
+        console.log(newMap)
     }
     return { saveComponent }
 }

--- a/src/hooks/useText.js
+++ b/src/hooks/useText.js
@@ -1,6 +1,7 @@
 import { useAtom } from "jotai";
 import { fontFamilyAtom, fontSizeAtom, fontStyleAtom, isUnderlineAtom, textColorAtom, textComponentsAtom } from "../atoms/TextAtom";
 import uuid from "react-uuid";
+import { canvasItemsAtom } from "../atoms/ComponentAtom";
 
 export const useText = () => {
     const [fontSize] = useAtom(fontSizeAtom);
@@ -8,27 +9,30 @@ export const useText = () => {
     const [color] = useAtom(textColorAtom);
     const [fontStyle] = useAtom(fontStyleAtom);
     const [isUnderline] = useAtom(isUnderlineAtom);
-    const [textComponents, setTextComponents] = useAtom(textComponentsAtom)
+    const [canvasItems, setCanvasItems] = useAtom(canvasItemsAtom);
     
     const addCanvasText = () => {
         let randomX = Math.random() * 150 - 75;
         let randomY = Math.random() * 150 - 75;
-        let newTextComponent = {
-            type: 'Text',
-            text: 'New Text',
+        let newText = {
+            id: uuid(),
+            type: 'text',
             x: 250 + randomX,
             y: 300 + randomY,
             width: 200,
             height: 30,
+            rotation: 0,
+            url: null,
+            text: 'New Text',
             fontSize: fontSize,
             fontFamily: fontFamily,
             color: color,
             fontStyle: fontStyle,
             isUnderline: isUnderline,
-            rotation: 0,
-            id: uuid(),
+            globalCompositeOperation: null,
+            points: null
         }
-        setTextComponents([...textComponents, newTextComponent]);
+        setCanvasItems([...canvasItems, newText]);
     }
 
     return { addCanvasText };


### PR DESCRIPTION
#33
#47

### 目的
作ったコンポーネントを画像で保存する

## 実装
Save Componentのボタンを押すとconsole.logでurlを表示する
TextをIconや手書きなどと同じcanvasItemsに格納する --> Clear Allで全削除ができる

## 不安点
消しゴムをImageやIconの上で使った時の消し具合が画像だと反映されない