### PR TITLE
mapの削除機能実装

### DIFF
--- a/src/components/Gallery/MapList.jsx
+++ b/src/components/Gallery/MapList.jsx
@@ -1,18 +1,19 @@
 import React from "react";
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from "react-router-dom";
 import { useSetAtom } from "jotai";
 import { currentMapAtom } from "../../atoms/CurrentMapAtom";
 import { canvasItemsAtom } from "../../atoms/ComponentAtom";
+import { deleteMap } from "../../db/map";
 
-const MapList = ({ mapList }) => {
-    const navigate = useNavigate();
-    const setCanvasItems = useSetAtom(canvasItemsAtom)
-    const setCurrentMap = useSetAtom(currentMapAtom)
+const MapList = ({ mapList, setMapList }) => {
+  const navigate = useNavigate();
+  const setCanvasItems = useSetAtom(canvasItemsAtom);
+  const setCurrentMap = useSetAtom(currentMapAtom);
   const handleEdit = (map) => {
-      navigate(`/map/${map.mapID}`);
-      setCurrentMap(map)
-      setCanvasItems(map.mapItems)
-  }
+    navigate(`/map/${map.mapID}`);
+    setCurrentMap(map);
+    setCanvasItems(map.mapItems);
+  };
 
   return (
     <>
@@ -26,6 +27,17 @@ const MapList = ({ mapList }) => {
             <img src={map.url} alt={map.title} />
           </a>
           <button onClick={() => handleEdit(map)}>edit</button>
+
+          <button
+            onClick={() => {
+              deleteMap(map.mapID);
+              setMapList(
+                mapList.filter((mapItem) => mapItem.mapID !== map.mapID)
+              );
+            }}
+          >
+            delete
+          </button>
         </div>
       ))}
     </>

--- a/src/components/Gallery/index.jsx
+++ b/src/components/Gallery/index.jsx
@@ -53,7 +53,7 @@ const Gallery = () => {
         className="mx-auto flex flex-wrap gap-4 mb-4"
         style={{ width: 1048 }}
       >
-        <MapList mapList={mapList} />
+        <MapList mapList={mapList} setMapList={setMapList} />
       </div>
       <button onClick={handleNewMap}>New Map</button>
       <div className="flex justify-center gap-1">

--- a/src/db/map.js
+++ b/src/db/map.js
@@ -1,4 +1,5 @@
-import { collection, doc, getDocs, query, setDoc, where } from "firebase/firestore";
+import { async } from "@firebase/util";
+import { collection, deleteDoc, doc, getDocs, query, setDoc, where } from "firebase/firestore";
 import { db } from "../client/firebase";
 
 export const postMap = (map) => {
@@ -19,4 +20,8 @@ export const getMaps = async (uid) => {
   return await Promise.all(querySnapshot.docs.map((doc) => {
     return doc.data();
   }));
+}
+
+export const deleteMap = async (mapID) => {
+  await deleteDoc(doc(db, "maps", mapID));
 }


### PR DESCRIPTION
## 目的
・mapを削除する

## 実装
・firebaseのdeleteDoc関数を用いてDB側のデータを削除
・クライアントのコードではmapListにfilter関数を用いて削除。この際、MapListのpropsにsetMapListを付与(Atom使うほどでもないような...あるような...)

## 未実装点
・削除ボタンのUIは手を加えていません。ギャラリーUI変更のPR時にまとめてお願いします。
・この先ギャラリーで他のユーザーのマップを見るとき、編集や削除、追加ボタンはレンダリングしないようにする必要があります。

close #58 