### PR TITLE
背景色と背景画像の設定

### DIFF
--- a/src/atoms/ComponentAtom.js
+++ b/src/atoms/ComponentAtom.js
@@ -4,6 +4,7 @@ export const canvasRefAtom = atom(null);
 export const canvasItemsAtom = atom([]);
 export const stageRefAtom = atom(null);
 export const backgroundImageAtom = atom(new Image());
+export const bgColorSettingAtom = atom(false);
 
 export const selectedIDAtom = atom(null);
 

--- a/src/atoms/ComponentAtom.js
+++ b/src/atoms/ComponentAtom.js
@@ -3,6 +3,7 @@ import { atom } from "jotai";
 export const canvasRefAtom = atom(null);
 export const canvasItemsAtom = atom([]);
 export const stageRefAtom = atom(null);
+export const backgroundImageAtom = atom(new Image());
 
 export const selectedIDAtom = atom(null);
 

--- a/src/components/CreateComponent/Buttons.jsx
+++ b/src/components/CreateComponent/Buttons.jsx
@@ -1,12 +1,12 @@
 import { useAtom } from "jotai";
 import React from "react";
-import { canvasItemsAtom } from "../../atoms/ComponentAtom";
+import { bgColorSettingAtom, canvasItemsAtom } from "../../atoms/ComponentAtom";
 import { useSave } from "../../hooks/useSave";
-
 
 const Buttons = () => {
     const [canvasItems, setCanvasItems] = useAtom(canvasItemsAtom);
     const { saveMap } = useSave();
+    const [isColorSetting, setIsColorSetting] = useAtom(bgColorSettingAtom)
 
     const handleClear = () => {
         setCanvasItems([]);
@@ -16,29 +16,43 @@ const Buttons = () => {
         if (canvasItems.length === 0) return;
         e.target.disabled = true;
         saveMap();
-        // Galleryに飛ばす
         setTimeout(() => {
             e.target.disabled = false;
         }, 5000);
     }
     return (
-        <div className="flex gap-4">
-            <div className="basis-1/2">
-                <button
-                    className="w-full text-center inline-block rounded-2xl border border-zinc-800 px-12 py-2 text-sm font-medium text-zinc-800 bg-white hover:bg-zinc-800 hover:text-white focus:outline-none focus:ring active:bg-zinc-800"
-                    onClick={handleClear}
-                >
-                    Clear All
-                </button>
+        <div className="m-0 p-0 h-12">
+             
+            <div className="flex gap-4">
+                <div className="w-5/12">
+                    <button
+                        className="w-full text-center inline-block rounded-2xl border border-zinc-800 px-12 py-2 text-sm font-medium text-zinc-800 bg-white hover:bg-zinc-800 hover:text-white focus:outline-none focus:ring active:bg-zinc-800"
+                        onClick={handleClear}
+                    >
+                        Clear All
+                    </button>
+                </div>
+                <div className="w-5/12">
+                    <button
+                        className="w-full text-center inline-block rounded-2xl border border-zinc-800 bg-zinc-800 px-12 py-2 text-sm font-medium text-white hover:bg-white hover:text-zinc-800 focus:outline-none focus:ring active:text-zinc-800"
+                        onClick={handleSave}
+                    >
+                        Save Component
+                    </button>
+                </div>
+                <div className="w-1/6">
+                    <button
+                        className="w-full text-center inline-block rounded-2xl h-10 border border-zinc-800 bg-zinc-800 px-12 py-2 text-sm font-medium text-white hover:bg-white hover:text-zinc-800 focus:outline-none focus:ring active:text-zinc-800"
+                        onClick={() => {
+                            setIsColorSetting(!isColorSetting)
+                        }}
+                        style={{background: "linear-gradient(60deg,#ffa07a, #ee82ee, #add8e6, #00ffff, #7fffd4,#ffff00, #ffa500)"}}
+                    >
+                    </button>
+                </div>
+                
             </div>
-            <div className="basis-1/2">
-                <button
-                    className="w-full text-center inline-block rounded-2xl border border-zinc-800 bg-zinc-800 px-12 py-2 text-sm font-medium text-white hover:bg-white hover:text-zinc-800 focus:outline-none focus:ring active:text-zinc-800"
-                    onClick={handleSave}
-                >
-                    Save Component
-                </button>
-            </div>
+        
         </div>
     );
 }

--- a/src/components/CreateComponent/Buttons.jsx
+++ b/src/components/CreateComponent/Buttons.jsx
@@ -1,17 +1,15 @@
 import { useAtom } from "jotai";
 import React from "react";
-import { canvasItemsAtom, stageRefAtom } from "../../atoms/ComponentAtom";
+import { canvasItemsAtom } from "../../atoms/ComponentAtom";
 import { useSave } from "../../hooks/useSave";
 
 
 const Buttons = () => {
     const [canvasItems, setCanvasItems] = useAtom(canvasItemsAtom);
-    const [stageRef] = useAtom(stageRefAtom);
     const { saveMap } = useSave();
 
     const handleClear = () => {
         setCanvasItems([]);
-        stageRef.current.children[0].children = [];
     }
 
     const handleSave = (e) => {

--- a/src/components/CreateComponent/CanvasArea.jsx
+++ b/src/components/CreateComponent/CanvasArea.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import Buttons from "./Buttons";
-import { Stage, Layer, Line, Image } from "react-konva";
+import { Stage, Layer, Line, Image, Rect } from "react-konva";
 import { useAtom, useAtomValue } from "jotai";
 import { backgroundImageAtom, backgroundRefAtom, canvasItemsAtom, selectedIDAtom, stageRefAtom } from "../../atoms/ComponentAtom";
 import ImageComponent from "./ImageComponent";
@@ -179,6 +179,13 @@ const CanvasArea = ({ }, canvasRef) => {
                     ref={stageRef}
                 >
                     <Layer>
+                        <Rect
+                            x={0}
+                            y={0}
+                            width={650}
+                            height={650}
+                            fill={currentMap.backgroundColor}
+                        />
                         <Image
                             width={650}
                             height={650}

--- a/src/components/CreateComponent/CanvasArea.jsx
+++ b/src/components/CreateComponent/CanvasArea.jsx
@@ -39,7 +39,7 @@ const CanvasArea = ({ }, canvasRef) => {
     const { isValidDrop } = useNewItem();
     const { startDrawing, endDrawing, moveDrawing } = useDrawing();
     const [bgColor, setBgColor] = useState('#FFFFFF');
-    const [isBgColorSetting] = useAtom(bgColorSettingAtom)
+    const [isBgColorSetting, setIsBgColorSetting] = useAtom(bgColorSettingAtom)
  
 
     function cancelSelectedText() {
@@ -61,6 +61,7 @@ const CanvasArea = ({ }, canvasRef) => {
     }
 
     const handleClick = (e) => {
+        setIsBgColorSetting(false);
         if (selectedText && (e.target == stageRef.current || e.target === backgroundRef.current)){
             cancelSelectedText();
         }

--- a/src/components/CreateComponent/CanvasArea.jsx
+++ b/src/components/CreateComponent/CanvasArea.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import Buttons from "./Buttons";
 import { Stage, Layer, Line, Image, Rect } from "react-konva";
 import { useAtom, useAtomValue } from "jotai";
-import { backgroundImageAtom, backgroundRefAtom, canvasItemsAtom, selectedIDAtom, stageRefAtom } from "../../atoms/ComponentAtom";
+import { backgroundImageAtom, bgColorSettingAtom, canvasItemsAtom, selectedIDAtom, stageRefAtom } from "../../atoms/ComponentAtom";
 import ImageComponent from "./ImageComponent";
 import { useNewItem } from "../../hooks/useNewItem";
 import { useDrawing } from "../../hooks/useDrawing";
@@ -10,6 +10,8 @@ import { userActionAtom } from "../../atoms/Atoms";
 import TextComponent from "./TextComponent";
 import { fontFamilyAtom, fontSizeAtom, fontStyleAtom, inputPositionAtom, isUnderlineAtom, selectedTextAtom, sizeChangingAtom, textColorAtom, textComponentsAtom } from "../../atoms/TextAtom";
 import { currentMapAtom } from "../../atoms/CurrentMapAtom";
+import { HexColorPicker } from "react-colorful"
+
 
 const CanvasArea = ({ }, canvasRef) => {
     const [inputPosition] = useAtom(inputPositionAtom);
@@ -36,6 +38,9 @@ const CanvasArea = ({ }, canvasRef) => {
     const backgroundImage = useAtomValue(backgroundImageAtom)
     const { isValidDrop } = useNewItem();
     const { startDrawing, endDrawing, moveDrawing } = useDrawing();
+    const [bgColor, setBgColor] = useState('#FFFFFF');
+    const [isBgColorSetting] = useAtom(bgColorSettingAtom)
+ 
 
     function cancelSelectedText() {
         if (hidingElement) {
@@ -161,6 +166,10 @@ const CanvasArea = ({ }, canvasRef) => {
         };
     }, [selectedId, isDragging, isTyping, selectedText, sizeChanging])
 
+    useEffect(() => {
+        currentMap.backgroundColor = bgColor;
+    },[bgColor])
+
 
     return (
         <div ref={canvasRef}>
@@ -265,6 +274,17 @@ const CanvasArea = ({ }, canvasRef) => {
                         onKeyDown={handleTextKeyDown}
                     />
                 }
+                {isBgColorSetting &&
+                    <div id="" className="fixed"
+                        style={{
+                            top: stageRef.current.attrs.container.getBoundingClientRect().top + 650 - 200,
+                            left: stageRef.current.attrs.container.getBoundingClientRect().left + 650 -200
+                        }}>
+                        <div className="flex justify-end m-0 p-0">
+                            <HexColorPicker color={bgColor} onChange={setBgColor} />
+                        </div>
+                    </div>
+                    }
                 <Buttons />
             </div>
         </div >

--- a/src/components/CreateComponent/CanvasArea.jsx
+++ b/src/components/CreateComponent/CanvasArea.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useRef } from "react";
 import Buttons from "./Buttons";
-import { Stage, Layer, Line } from "react-konva";
-import { useAtom } from "jotai";
-import { canvasItemsAtom, selectedIDAtom, stageRefAtom } from "../../atoms/ComponentAtom";
+import { Stage, Layer, Line, Image } from "react-konva";
+import { useAtom, useAtomValue } from "jotai";
+import { backgroundImageAtom, backgroundRefAtom, canvasItemsAtom, selectedIDAtom, stageRefAtom } from "../../atoms/ComponentAtom";
 import ImageComponent from "./ImageComponent";
 import { useNewItem } from "../../hooks/useNewItem";
 import { useDrawing } from "../../hooks/useDrawing";
@@ -32,6 +32,8 @@ const CanvasArea = ({ }, canvasRef) => {
     const [userAction] = useAtom(userActionAtom);
     const [currentMap] = useAtom(currentMapAtom)
     const stageRef = useRef(null);
+    const backgroundRef = useRef(null)
+    const backgroundImage = useAtomValue(backgroundImageAtom)
     const { isValidDrop } = useNewItem();
     const { startDrawing, endDrawing, moveDrawing } = useDrawing();
 
@@ -46,15 +48,15 @@ const CanvasArea = ({ }, canvasRef) => {
         setHidingElement([]);
     }
 
-    const handleClick = (e) => {
-        if (selectedText && stageRef.current === e.target) {
+
+    const handleTextKeyDown = (e) => {
+        if (e.key === 'Enter' && !e.shiftKey || e.key === 'Escape') {
             cancelSelectedText();
         }
     }
 
-
-    const handleTextKeyDown = (e) => {
-        if (e.key === 'Enter' && !e.shiftKey || e.key === 'Escape') {
+    const handleClick = (e) => {
+        if (selectedText && (e.target == stageRef.current || e.target === backgroundRef.current)){
             cancelSelectedText();
         }
     }
@@ -108,7 +110,8 @@ const CanvasArea = ({ }, canvasRef) => {
     }, [isUnderline])
 
     const checkDeselect = (e) => {
-        const clickedOnEmpty = e.target === e.target.getStage();
+        // const clickedOnEmpty = e.target === e.target.getStage();
+        const clickedOnEmpty = e.target === backgroundRef.current;
         if (clickedOnEmpty) {
             selectImage(null);
         }
@@ -148,7 +151,6 @@ const CanvasArea = ({ }, canvasRef) => {
 
     useEffect(() => {
         setStageRefAtom(stageRef);
-        console.log("container")
         stageRef.current.container().style.backgroundColor = currentMap.backgroundColor;
     },[])
 
@@ -173,10 +175,16 @@ const CanvasArea = ({ }, canvasRef) => {
                     onTouchMove={handleMouseMove}
                     onDragStart={() => setIsDragging(true)}
                     onDragEnd={removeOut}
-                    ref={stageRef}
                     onClick={handleClick}
+                    ref={stageRef}
                 >
                     <Layer>
+                        <Image
+                            width={650}
+                            height={650}
+                            image={backgroundImage}
+                            ref={backgroundRef}
+                        />
                         {canvasItems.map((item, i) => (
                             item.type === 'line' ?
                                 <Line

--- a/src/components/CreateComponent/CanvasArea.jsx
+++ b/src/components/CreateComponent/CanvasArea.jsx
@@ -9,6 +9,7 @@ import { useDrawing } from "../../hooks/useDrawing";
 import { userActionAtom } from "../../atoms/Atoms";
 import TextComponent from "./TextComponent";
 import { fontFamilyAtom, fontSizeAtom, fontStyleAtom, inputPositionAtom, isUnderlineAtom, selectedTextAtom, sizeChangingAtom, textColorAtom, textComponentsAtom } from "../../atoms/TextAtom";
+import { currentMapAtom } from "../../atoms/CurrentMapAtom";
 
 const CanvasArea = ({ }, canvasRef) => {
     const [inputPosition] = useAtom(inputPositionAtom);
@@ -29,6 +30,7 @@ const CanvasArea = ({ }, canvasRef) => {
     const [isDragging, setIsDragging] = useState(false);
     const [canvasItems, setCanvasItems] = useAtom(canvasItemsAtom);
     const [userAction] = useAtom(userActionAtom);
+    const [currentMap] = useAtom(currentMapAtom)
     const stageRef = useRef(null);
     const { isValidDrop } = useNewItem();
     const { startDrawing, endDrawing, moveDrawing } = useDrawing();
@@ -146,6 +148,8 @@ const CanvasArea = ({ }, canvasRef) => {
 
     useEffect(() => {
         setStageRefAtom(stageRef);
+        console.log("container")
+        stageRef.current.container().style.backgroundColor = currentMap.backgroundColor;
     },[])
 
     useEffect(() => {

--- a/src/components/CreateComponent/ImageComponent.jsx
+++ b/src/components/CreateComponent/ImageComponent.jsx
@@ -5,7 +5,7 @@ import useImage from 'use-image';
 import { userActionAtom } from '../../atoms/Atoms';
 
 const ImageComponent = ({imgProps, isSelected, onSelect, onChange }) => {
-    const [image] = useImage(imgProps.url);
+    const [image] = useImage(imgProps.url, 'anonymous');
     const componentRef = useRef();
     const trRef = useRef();
     const [userAction] = useAtom(userActionAtom)
@@ -16,6 +16,7 @@ const ImageComponent = ({imgProps, isSelected, onSelect, onChange }) => {
             trRef.current.getLayer().batchDraw();
         }
     }, [isSelected]);
+
   
     return (
     <React.Fragment>

--- a/src/components/CreateComponent/Sidebar/DrawingTab.jsx
+++ b/src/components/CreateComponent/Sidebar/DrawingTab.jsx
@@ -46,19 +46,6 @@ const DrawingTab = () => {
                 <div className="m-1 border" style={{backgroundColor: '#D8BFD8', width: '15%', height: 55}} onClick={handleBackground} />
                 <div className="m-1 border" style={{backgroundColor: '#E0FFFF', width: '15%', height: 55}} onClick={handleBackground} />
             </div>
-            <label className="block mt-3 mb-2 text-sm font-medium text-gray-300">Background Style</label>
-            <div className="flex">
-                <select className="border border-gray-300 rounded-lg px-2 py-1 mr-2" onChange={handleBgStyle}>
-                    <option value=""
-                        >normal</option>          
-                    <option value="https://firebasestorage.googleapis.com/v0/b/watashi-1d6aa.appspot.com/o/images%2FH1fCgz3jWpgOn4nugDkJF6Dqq0D3%2Ffg9elbeh.webp?alt=media&token=dafaa98e-6bc8-4dc6-b5ad-dcac831b3cba"
-                        >paper</option>
-                    <option value="https://firebasestorage.googleapis.com/v0/b/watashi-1d6aa.appspot.com/o/images%2FH1fCgz3jWpgOn4nugDkJF6Dqq0D3%2Focqolnic.jpg?alt=media&token=b2e6dcc4-8394-4f72-89fd-5107dc39a7b4"
-                        >wood</option>
-                    <option value="https://firebasestorage.googleapis.com/v0/b/watashi-1d6aa.appspot.com/o/images%2FH1fCgz3jWpgOn4nugDkJF6Dqq0D3%2Flywwmck8.jpg?alt=media&token=8651f699-e012-46d1-a16b-c39f7eefabce"
-                        >brick</option>
-                </select>
-            </div>
             
         </div>
     );

--- a/src/components/CreateComponent/Sidebar/DrawingTab.jsx
+++ b/src/components/CreateComponent/Sidebar/DrawingTab.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useAtom } from "jotai";
-import { paintColorAtom, paintModeAtom, paintWidthAtom, stageRefAtom } from "../../../atoms/ComponentAtom";
+import { backgroundImageAtom, paintColorAtom, paintModeAtom, paintWidthAtom, stageRefAtom } from "../../../atoms/ComponentAtom";
 import { HexColorPicker } from "react-colorful"
 import { currentMapAtom } from "../../../atoms/CurrentMapAtom";
 
@@ -10,12 +10,22 @@ const DrawingTab = () => {
     const [paintWidth, setPaintWidth] = useAtom(paintWidthAtom);
     const [paintColor, setPaintColor] = useAtom(paintColorAtom);
     const [currentMap] = useAtom(currentMapAtom);
-    const [stageRef] = useAtom(stageRefAtom)
+    const [stageRef] = useAtom(stageRefAtom);
+    const [backgroundImage, setBgImg] = useAtom(backgroundImageAtom)
 
     const handleBackground = (e) => {
+        setBgImg(new Image())
         const value = e.target.style.backgroundColor;
         currentMap.backgroundColor = value;
         stageRef.current.container().style.backgroundColor = value;
+    }
+
+    const handleBgStyle = (e) => {
+        let newImg = new Image();
+        newImg.src = e.target.value;
+        setBgImg(newImg)
+        currentMap.backgroundColor = 'white';
+        stageRef.current.container().style.backgroundColor = 'white'
     }
 
     return (
@@ -30,15 +40,29 @@ const DrawingTab = () => {
             </div>
             <HexColorPicker color={paintColor} onChange={setPaintColor} style={{ width: '100%' }} />
             <label className="block mt-3 mb-2 text-sm font-medium text-gray-300">Background Type</label>
-            <div className="flex ">
-                <div className="m-1 border" style={{backgroundColor: '#FFFFE0', width: '20%', height: 70}} onClick={handleBackground} />
-                <div className="m-1 border" style={{backgroundColor: '#FFC0CB', width: '20%', height: 70}} onClick={handleBackground} />
-                <div className="m-1 border" style={{backgroundColor: '#FFA07A', width: '20%', height: 70}} onClick={handleBackground} />
-                <div className="m-1 border" style={{backgroundColor: '#D8BFD8', width: '20%', height: 70}} onClick={handleBackground} />
-                <div className="m-1 border" style={{backgroundColor: '#E0FFFF', width: '20%', height: 70}} onClick={handleBackground} />
+            <div className="flex">
+                <div className="m-1 border" style={{backgroundColor: '#FFFFFF', width: '15%', height: 55}} onClick={handleBackground} />
+                <div className="m-1 border" style={{backgroundColor: '#FFFFE0', width: '15%', height: 55}} onClick={handleBackground} />
+                <div className="m-1 border" style={{backgroundColor: '#FFC0CB', width: '15%', height: 55}} onClick={handleBackground} />
+                <div className="m-1 border" style={{backgroundColor: '#FFA07A', width: '15%', height: 55}} onClick={handleBackground} />
+                <div className="m-1 border" style={{backgroundColor: '#D8BFD8', width: '15%', height: 55}} onClick={handleBackground} />
+                <div className="m-1 border" style={{backgroundColor: '#E0FFFF', width: '15%', height: 55}} onClick={handleBackground} />
             </div>
+            <label className="block mt-3 mb-2 text-sm font-medium text-gray-300">Background Style</label>
+            <div className="flex">
+                <select className="border border-gray-300 rounded-lg px-2 py-1 mr-2" onChange={handleBgStyle}>
+                    <option value=""
+                        >normal</option>          
+                    <option value="https://firebasestorage.googleapis.com/v0/b/watashi-1d6aa.appspot.com/o/images%2FH1fCgz3jWpgOn4nugDkJF6Dqq0D3%2Ffg9elbeh.webp?alt=media&token=dafaa98e-6bc8-4dc6-b5ad-dcac831b3cba"
+                        >paper</option>
+                    <option value="https://firebasestorage.googleapis.com/v0/b/watashi-1d6aa.appspot.com/o/images%2FH1fCgz3jWpgOn4nugDkJF6Dqq0D3%2Focqolnic.jpg?alt=media&token=b2e6dcc4-8394-4f72-89fd-5107dc39a7b4"
+                        >wood</option>
+                    <option value="https://firebasestorage.googleapis.com/v0/b/watashi-1d6aa.appspot.com/o/images%2FH1fCgz3jWpgOn4nugDkJF6Dqq0D3%2Flywwmck8.jpg?alt=media&token=8651f699-e012-46d1-a16b-c39f7eefabce"
+                        >brick</option>
+                </select>
+            </div>
+            
         </div>
     );
 }
-
 export default DrawingTab;

--- a/src/components/CreateComponent/Sidebar/DrawingTab.jsx
+++ b/src/components/CreateComponent/Sidebar/DrawingTab.jsx
@@ -1,13 +1,22 @@
 import React from "react";
 import { useAtom } from "jotai";
-import { paintColorAtom, paintModeAtom, paintWidthAtom } from "../../../atoms/ComponentAtom";
+import { paintColorAtom, paintModeAtom, paintWidthAtom, stageRefAtom } from "../../../atoms/ComponentAtom";
 import { HexColorPicker } from "react-colorful"
+import { currentMapAtom } from "../../../atoms/CurrentMapAtom";
 
 
 const DrawingTab = () => {
     const [paintMode, setPaintMode] = useAtom(paintModeAtom);
     const [paintWidth, setPaintWidth] = useAtom(paintWidthAtom);
     const [paintColor, setPaintColor] = useAtom(paintColorAtom);
+    const [currentMap] = useAtom(currentMapAtom);
+    const [stageRef] = useAtom(stageRefAtom)
+
+    const handleBackground = (e) => {
+        const value = e.target.style.backgroundColor;
+        currentMap.backgroundColor = value;
+        stageRef.current.container().style.backgroundColor = value;
+    }
 
     return (
         <div>
@@ -20,6 +29,14 @@ const DrawingTab = () => {
                     value={paintWidth} onChange={(e) => setPaintWidth(e.target.value)} />
             </div>
             <HexColorPicker color={paintColor} onChange={setPaintColor} style={{ width: '100%' }} />
+            <label className="block mt-3 mb-2 text-sm font-medium text-gray-300">Background Type</label>
+            <div className="flex ">
+                <div className="m-1 border" style={{backgroundColor: '#FFFFE0', width: '20%', height: 70}} onClick={handleBackground} />
+                <div className="m-1 border" style={{backgroundColor: '#FFC0CB', width: '20%', height: 70}} onClick={handleBackground} />
+                <div className="m-1 border" style={{backgroundColor: '#FFA07A', width: '20%', height: 70}} onClick={handleBackground} />
+                <div className="m-1 border" style={{backgroundColor: '#D8BFD8', width: '20%', height: 70}} onClick={handleBackground} />
+                <div className="m-1 border" style={{backgroundColor: '#E0FFFF', width: '20%', height: 70}} onClick={handleBackground} />
+            </div>
         </div>
     );
 }

--- a/src/components/CreateComponent/Sidebar/DrawingTab.jsx
+++ b/src/components/CreateComponent/Sidebar/DrawingTab.jsx
@@ -1,31 +1,15 @@
 import React from "react";
 import { useAtom } from "jotai";
-import { backgroundImageAtom, paintColorAtom, paintModeAtom, paintWidthAtom } from "../../../atoms/ComponentAtom";
+import { paintColorAtom, paintModeAtom, paintWidthAtom } from "../../../atoms/ComponentAtom";
 import { HexColorPicker } from "react-colorful"
-import { currentMapAtom } from "../../../atoms/CurrentMapAtom";
 
 
 const DrawingTab = () => {
     const [paintMode, setPaintMode] = useAtom(paintModeAtom);
     const [paintWidth, setPaintWidth] = useAtom(paintWidthAtom);
     const [paintColor, setPaintColor] = useAtom(paintColorAtom);
-    const [currentMap] = useAtom(currentMapAtom);
-    const [backgroundImage, setBgImg] = useAtom(backgroundImageAtom)
 
-    const handleBackground = (e) => {
-        setBgImg(new Image())
-        const value = e.target.style.backgroundColor;
-        currentMap.backgroundColor = value;
-    }
-
-    const handleBgStyle = (e) => {
-        let newImg = new Image();
-        newImg.crossOrigin = 'Anonymous';
-        newImg.src = e.target.value;
-        setBgImg(newImg)
-        currentMap.backgroundColor = 'white';
-    }
-
+    
     return (
         <div>
             <div className="mb-2">
@@ -37,16 +21,6 @@ const DrawingTab = () => {
                     value={paintWidth} onChange={(e) => setPaintWidth(e.target.value)} />
             </div>
             <HexColorPicker color={paintColor} onChange={setPaintColor} style={{ width: '100%' }} />
-            <label className="block mt-3 mb-2 text-sm font-medium text-gray-300">Background Type</label>
-            <div className="flex">
-                <div className="m-1 border" style={{backgroundColor: '#FFFFFF', width: '15%', height: 55}} onClick={handleBackground} />
-                <div className="m-1 border" style={{backgroundColor: '#FFFFE0', width: '15%', height: 55}} onClick={handleBackground} />
-                <div className="m-1 border" style={{backgroundColor: '#FFC0CB', width: '15%', height: 55}} onClick={handleBackground} />
-                <div className="m-1 border" style={{backgroundColor: '#FFA07A', width: '15%', height: 55}} onClick={handleBackground} />
-                <div className="m-1 border" style={{backgroundColor: '#D8BFD8', width: '15%', height: 55}} onClick={handleBackground} />
-                <div className="m-1 border" style={{backgroundColor: '#E0FFFF', width: '15%', height: 55}} onClick={handleBackground} />
-            </div>
-            
         </div>
     );
 }

--- a/src/components/CreateComponent/Sidebar/DrawingTab.jsx
+++ b/src/components/CreateComponent/Sidebar/DrawingTab.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useAtom } from "jotai";
-import { backgroundImageAtom, paintColorAtom, paintModeAtom, paintWidthAtom, stageRefAtom } from "../../../atoms/ComponentAtom";
+import { backgroundImageAtom, paintColorAtom, paintModeAtom, paintWidthAtom } from "../../../atoms/ComponentAtom";
 import { HexColorPicker } from "react-colorful"
 import { currentMapAtom } from "../../../atoms/CurrentMapAtom";
 
@@ -10,22 +10,20 @@ const DrawingTab = () => {
     const [paintWidth, setPaintWidth] = useAtom(paintWidthAtom);
     const [paintColor, setPaintColor] = useAtom(paintColorAtom);
     const [currentMap] = useAtom(currentMapAtom);
-    const [stageRef] = useAtom(stageRefAtom);
     const [backgroundImage, setBgImg] = useAtom(backgroundImageAtom)
 
     const handleBackground = (e) => {
         setBgImg(new Image())
         const value = e.target.style.backgroundColor;
         currentMap.backgroundColor = value;
-        stageRef.current.container().style.backgroundColor = value;
     }
 
     const handleBgStyle = (e) => {
         let newImg = new Image();
+        newImg.crossOrigin = 'Anonymous';
         newImg.src = e.target.value;
         setBgImg(newImg)
         currentMap.backgroundColor = 'white';
-        stageRef.current.container().style.backgroundColor = 'white'
     }
 
     return (

--- a/src/components/CreateComponent/Sidebar/ImageTab.jsx
+++ b/src/components/CreateComponent/Sidebar/ImageTab.jsx
@@ -1,14 +1,16 @@
 import { useAtom } from "jotai";
 import { useUploadImg } from "../../../hooks/useUploadimg";
-import { canvasRefAtom } from "../../../atoms/ComponentAtom";
+import { backgroundImageAtom, canvasRefAtom } from "../../../atoms/ComponentAtom";
 import { useNewItem } from "../../../hooks/useNewItem";
-import { useState } from "react";
+import { useState, useRef } from "react";
 
 const ImageTab = () => {
     const { uploadedImages, uploadToServer, deleteUploadedImage } = useUploadImg();
     const [canvasAtom] = useAtom(canvasRefAtom);
     const [shift, setShift] = useState({ x: 0, y: 0 });
     const { isValidDrop, addItem } = useNewItem();
+    const setBgRef = useRef(null);
+    const [backgroundImage, setBackgroundImage] = useAtom(backgroundImageAtom);
 
     const handleShift = (e) => {
         setShift({
@@ -17,8 +19,19 @@ const ImageTab = () => {
         })
     }
 
+    const setBackgroundImg = (e) => {
+        let newBg = new Image();
+        newBg.crossOrigin = 'anonymous';
+        newBg.src = e.target.src;
+        setBackgroundImage(newBg);
+    }
+
     const addImage = (e) => {
-        e.preventDefault();
+        e.preventDefault(e);
+        if(!backgroundImage.src && isValidDrop(e, setBgRef)){
+            setBackgroundImg(e);
+            return;
+        }
         if (!isValidDrop(e, canvasAtom)) {
             return;
         }
@@ -31,6 +44,8 @@ const ImageTab = () => {
         }
         addItem(newImage, canvasAtom);
     }
+
+
     return (
         <>
             <div className="mb-2">
@@ -44,7 +59,7 @@ const ImageTab = () => {
                     onChange={uploadToServer}
                 ></input>
             </div>
-            <div className="overflow-y-scroll border rounded-lg p-3" style={{ height: 496 }}>
+            <div className="overflow-y-scroll border rounded-lg p-3" style={{ height: 360 }}>
                 <div className="flex flex-wrap justify-between">
                     {uploadedImages.map((uploadedPath) => {
                         return (
@@ -72,6 +87,30 @@ const ImageTab = () => {
                             </>
                         );
                     })}
+                </div>
+            </div>
+            <div>
+                <label className="block mb-1 mt-2 text-sm font-medium text-gray-300">Background Image</label>
+                <div className="border rounded flex justify-center items-center" style={{height: 110}}
+                >
+                    {backgroundImage.src && 
+                    <div className="relative" style={{height: 100, width: 100}}>
+                        <img src={backgroundImage.src} />
+                        <button className="absolute border align-middle rounded-full bg-gray-300 text-lg -top-2 -right-2 w-7 h-7 flex justify-center items-center border-white border-2"
+                            onClick={() => {
+                                setBackgroundImage(new Image())
+                            }}
+                        ><div className="">×</div>
+                        </button>
+                    </div>
+                    }
+                    {!backgroundImage.src && 
+                    <div className="border-dashed border-2 flex justify-center items-center" style={{height: 100, width: 100}}
+                        ref={setBgRef}
+                        onDragOver={(e)=> e.preventDefault()}>
+                        <p className="text-slate-400">drop here</p>
+                    </div>
+                    }
                 </div>
             </div>
         </>

--- a/src/components/CreateComponent/index.jsx
+++ b/src/components/CreateComponent/index.jsx
@@ -3,9 +3,8 @@ import { useRef } from "react";
 import { forwardRef } from "react";
 import CanvasArea from "./CanvasArea";
 import Sidebar from "./Sidebar";
-import { useAtom, useSetAtom } from "jotai";
+import { useAtom } from "jotai";
 import { canvasRefAtom } from "../../atoms/ComponentAtom";
-import { currentMapAtom } from "../../atoms/CurrentMapAtom";
 
 const CreateComponent = () => {
   const WrappedCanvasArea = forwardRef(CanvasArea);
@@ -14,6 +13,7 @@ const CreateComponent = () => {
 
   useEffect(() => {
     setCanvasAtom(canvasRef);
+    // currentMapをfetch
   }, [])
 
   return (

--- a/src/components/CreateComponent/index.jsx
+++ b/src/components/CreateComponent/index.jsx
@@ -3,8 +3,9 @@ import { useRef } from "react";
 import { forwardRef } from "react";
 import CanvasArea from "./CanvasArea";
 import Sidebar from "./Sidebar";
-import { useAtom } from "jotai";
+import { useAtom, useSetAtom } from "jotai";
 import { canvasRefAtom } from "../../atoms/ComponentAtom";
+import { currentMapAtom } from "../../atoms/CurrentMapAtom";
 
 const CreateComponent = () => {
   const WrappedCanvasArea = forwardRef(CanvasArea);

--- a/src/hooks/useSave.js
+++ b/src/hooks/useSave.js
@@ -83,6 +83,7 @@ export const useSave = () => {
 
     const saveMap = () => {
         // 画像urlを取得してdatabaseのMapを新規追加/書き換え
+        // 非同期で画像が前に来てしまう
         stageRef.current.children[0].children = [];
         setBackground();
         
@@ -91,7 +92,7 @@ export const useSave = () => {
             updateMap(data);
             setCanvasItems([]);
             stageRef.current.children[0].children = [];
-        }, 2000);
+        }, 3000);
     }
 
 

--- a/src/hooks/useSave.js
+++ b/src/hooks/useSave.js
@@ -1,16 +1,14 @@
 import { useAtom, useAtomValue } from "jotai"
 import { backgroundImageAtom, canvasItemsAtom, stageRefAtom } from "./../atoms/ComponentAtom";
 import { currentMapAtom } from "../atoms/CurrentMapAtom";
-import Konva from "konva";
 import { postMap } from "../db/map";
 
 export const useSave = () => {
     const [canvasItems, setCanvasItems] = useAtom(canvasItemsAtom);
     const [stageRef] = useAtom(stageRefAtom);
     const currentMap = useAtomValue(currentMapAtom)
-    const backgroundImage = useAtomValue(backgroundImageAtom)
 
-    const saveMap = async () => {
+    const saveMap = () => {
         let data = stageRef.current.toDataURL();
         updateMap(data);
     }

--- a/src/hooks/useSave.js
+++ b/src/hooks/useSave.js
@@ -1,5 +1,5 @@
 import { useAtom, useAtomValue } from "jotai"
-import { canvasItemsAtom, stageRefAtom } from "./../atoms/ComponentAtom";
+import { backgroundImageAtom, canvasItemsAtom, stageRefAtom } from "./../atoms/ComponentAtom";
 import { currentMapAtom } from "../atoms/CurrentMapAtom";
 import Konva from "konva";
 import { postMap } from "../db/map";
@@ -8,6 +8,7 @@ export const useSave = () => {
     const [canvasItems, setCanvasItems] = useAtom(canvasItemsAtom);
     const [stageRef] = useAtom(stageRefAtom);
     const currentMap = useAtomValue(currentMapAtom)
+    const backgroundImage = useAtomValue(backgroundImageAtom)
 
     const addItemOnCanvas = (item) => {
         if(item.type === 'line'){
@@ -54,12 +55,36 @@ export const useSave = () => {
         }
     }
 
+    const setBackground = () => {
+        stageRef.current.children[0].add(new Konva.Rect({
+            x: 0,
+            y: 0,
+            width: 650,
+            height: 650,
+            fill: currentMap.backgroundColor,
+        }))
+        let imgObj = new Image();
+            
+        imgObj.onload = function(){
+            stageRef.current.children[0].add(new Konva.Image({
+                image: imgObj,
+                x: 0,
+                y: 0,
+                width: 650,
+                height: 650,
+            }))
+            for(let item of canvasItems) {
+                addItemOnCanvas(item);   
+            }
+        }
+        imgObj.crossOrigin = "Anonymous";
+        imgObj.src = backgroundImage.src;
+    }
+
     const saveMap = () => {
         // 画像urlを取得してdatabaseのMapを新規追加/書き換え
         stageRef.current.children[0].children = [];
-        for(let item of canvasItems) {
-            addItemOnCanvas(item);   
-        }
+        setBackground();
         
         setTimeout(() => {
             let data = stageRef.current.toDataURL();

--- a/src/hooks/useSave.js
+++ b/src/hooks/useSave.js
@@ -10,89 +10,9 @@ export const useSave = () => {
     const currentMap = useAtomValue(currentMapAtom)
     const backgroundImage = useAtomValue(backgroundImageAtom)
 
-    const addItemOnCanvas = (item) => {
-        if(item.type === 'line'){
-            stageRef.current.children[0].add(new Konva.Line({
-                key: item.id,
-                id: item.type,
-                stroke: item.color,
-                strokeWidth: item.width,
-                globalCompositeOperation: item.globalCompositeOperation,
-                lineCap: "round",
-                lineJoin: "round",
-                points: item.points,
-            }))
-        }
-        else if(item.type === 'icon' || item.type === 'image') {
-            let imgObj = new Image();
-            
-            imgObj.onload = function(){
-                stageRef.current.children[0].add(new Konva.Image({
-                    image: imgObj,
-                    x: item.x,
-                    y: item.y,
-                    width: item.width,
-                    height: item.height,
-                    rotation: item.rotation
-                }))
-            }
-            imgObj.crossOrigin = "Anonymous";
-            imgObj.src = item.url;
-            
-        }
-        else if(item.type === 'text') {
-            stageRef.current.children[0].add(new Konva.Text({
-                text: item.text,
-                x: item.x,
-                y: item.y,
-                fontSize: item.fontSize,
-                fontFamily: item.fontFamily,
-                width: item.width,
-                fontStyle: item.fontStyle,
-                textDecoration: item.isUnderline ? 'underline' : '',
-                fill: item.color,
-            }))
-        }
-    }
-
-    const setBackground = () => {
-        stageRef.current.children[0].add(new Konva.Rect({
-            x: 0,
-            y: 0,
-            width: 650,
-            height: 650,
-            fill: currentMap.backgroundColor,
-        }))
-        let imgObj = new Image();
-            
-        imgObj.onload = function(){
-            stageRef.current.children[0].add(new Konva.Image({
-                image: imgObj,
-                x: 0,
-                y: 0,
-                width: 650,
-                height: 650,
-            }))
-            for(let item of canvasItems) {
-                addItemOnCanvas(item);   
-            }
-        }
-        imgObj.crossOrigin = "Anonymous";
-        imgObj.src = backgroundImage.src;
-    }
-
-    const saveMap = () => {
-        // 画像urlを取得してdatabaseのMapを新規追加/書き換え
-        // 非同期で画像が前に来てしまう
-        stageRef.current.children[0].children = [];
-        setBackground();
-        
-        setTimeout(() => {
-            let data = stageRef.current.toDataURL();
-            updateMap(data);
-            setCanvasItems([]);
-            stageRef.current.children[0].children = [];
-        }, 3000);
+    const saveMap = async () => {
+        let data = stageRef.current.toDataURL();
+        updateMap(data);
     }
 
 


### PR DESCRIPTION
#60 saveMapがsetTimeOutなしで実行できる
#51 background color設定

## 実装
・background imageはimageタブからドラッグ&ドロップで設定、✘ボタンで解除
・colorはsave component(map)のボタンの隣のカラフルなボタンでHex Pickerが出現。再度押すと隠れる

## できるようになったこと
save mapの時にItemsを置き直すことをやめたので、saveした後もそのまま編集できる
save mapの処理が圧倒的に速くなった

## 微妙な点
画像をcanvasに置くときに時間が１秒ほどかかる(Cross origin設定をここでするため)
