### PR TITLE
手書き線のUndo, Redo機能追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react": "^18.2.0",
         "react-colorful": "^5.6.1",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.6.0",
         "react-konva": "^18.2.2",
         "react-router-dom": "^6.4.2",
         "react-scripts": "5.0.1",
@@ -14949,6 +14950,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-icons": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.6.0.tgz",
+      "integrity": "sha512-rR/L9m9340yO8yv1QT1QurxWQvWpbNHqVX0fzMln2HEb9TEIrQRGsqiNFQfiv9/JEUbyHmHPlNTB2LWm2Ttz0g==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -28463,6 +28472,12 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "react-icons": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.6.0.tgz",
+      "integrity": "sha512-rR/L9m9340yO8yv1QT1QurxWQvWpbNHqVX0fzMln2HEb9TEIrQRGsqiNFQfiv9/JEUbyHmHPlNTB2LWm2Ttz0g==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react": "^18.2.0",
     "react-colorful": "^5.6.1",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.6.0",
     "react-konva": "^18.2.2",
     "react-router-dom": "^6.4.2",
     "react-scripts": "5.0.1",

--- a/src/components/CreateComponent/Sidebar/DrawingTab.jsx
+++ b/src/components/CreateComponent/Sidebar/DrawingTab.jsx
@@ -1,23 +1,54 @@
 import React from "react";
 import { useAtom } from "jotai";
-import { paintColorAtom, paintModeAtom, paintWidthAtom } from "../../../atoms/ComponentAtom";
+import { canvasItemsAtom, paintColorAtom, paintModeAtom, paintWidthAtom } from "../../../atoms/ComponentAtom";
 import { HexColorPicker } from "react-colorful"
+import { IconContext } from "react-icons";
+import { BiUndo, BiRedo } from 'react-icons/bi'
+import { useState } from "react";
 
 
 const DrawingTab = () => {
     const [paintMode, setPaintMode] = useAtom(paintModeAtom);
     const [paintWidth, setPaintWidth] = useAtom(paintWidthAtom);
     const [paintColor, setPaintColor] = useAtom(paintColorAtom);
+    const [undoCount, setUndoCount] = useState(0);
+    const [canvasItems, setCanvasItems] = useAtom(canvasItemsAtom);
+
+    const undoLine = () => {
+        let line = canvasItems.slice().reverse().find(item => item.type === 'line');
+        line.type = 'null'
+        setCanvasItems(canvasItems.map(item => item.id === line.id ? line : item));
+        setUndoCount(undoCount + 1);
+    }
+
+    const redoLine = () => {
+        let line = canvasItems.find(item => item.type === 'null');
+        line.type = 'line';
+        setCanvasItems(canvasItems.map(item => item.id === line ? line : item));
+        setUndoCount(undoCount - 1);
+    }
 
     return (
         <div>
-            <div className="mb-2">
+            <div className="mb-2 flex">
                 <select className="border border-gray-300 rounded-lg px-2 py-1 mr-2" value={paintMode} onChange={(e) => setPaintMode(e.target.value)}>
                     <option value="brush">Brush</option>
                     <option value="eraser">Erasor</option>
                 </select>
                 <input type="range" min='1' max='10'
                     value={paintWidth} onChange={(e) => setPaintWidth(e.target.value)} />
+                <div className="flex ml-2">
+                    <button className="m-1" disabled={!canvasItems.filter(item => item.type === 'line').length} onClick={undoLine}>
+                        <IconContext.Provider value={{ color: canvasItems.filter(item => item.type === 'line').length ? 'black' : 'gray', size: '40px'}}>
+                            <BiUndo />
+                        </IconContext.Provider>
+                    </button>
+                    <button className="m-1" disabled={undoCount <= 0} onClick={redoLine}>
+                        <IconContext.Provider value={{ color: undoCount <= 0 ? 'gray': 'black', size: '40px'}}>
+                            <BiRedo />
+                        </IconContext.Provider>
+                    </button>
+                </div>
             </div>
             <HexColorPicker color={paintColor} onChange={setPaintColor} style={{ width: '100%' }} />
         </div>


### PR DESCRIPTION
#41 
## 実装
Drawing Tabの矢印(左がUndo)クリックで直近に書かれた線が削除される。
RedoボタンでUndoされた線を復活。

## 実装内容
canvasItemsのLineのtypeをnullにすることで画面に表示しないようにした
RedoでtypeをLineに戻すだけなので配列内のインデックスやキャンバス上の重なり順は変わらない