### PR TITLE
CreateaComponentのindex.jsxでcurrentMapをfetch

### DIFF
--- a/src/components/CreateComponent/index.jsx
+++ b/src/components/CreateComponent/index.jsx
@@ -3,16 +3,44 @@ import { useRef } from "react";
 import { forwardRef } from "react";
 import CanvasArea from "./CanvasArea";
 import Sidebar from "./Sidebar";
-import { useAtom } from "jotai";
-import { canvasRefAtom } from "../../atoms/ComponentAtom";
+import { useAtom, useAtomValue } from "jotai";
+import { canvasItemsAtom, canvasRefAtom } from "../../atoms/ComponentAtom";
+import { useParams } from "react-router-dom";
+import { fetchCurrentMap } from "../../db/map";
+import { currentMapAtom } from "../../atoms/CurrentMapAtom";
+import { auth } from "../../client/firebase";
 
 const CreateComponent = () => {
   const WrappedCanvasArea = forwardRef(CanvasArea);
   const canvasRef = useRef();
   const [, setCanvasAtom] = useAtom(canvasRefAtom);
+  const params = useParams();
+  const [currentMap, setCurrentMap] = useAtom(currentMapAtom);
+  const [canvasItems, setCanvasItems] = useAtom(canvasItemsAtom);
+
+  const createNewMap = () => {
+    const newMap = {
+      mapID: params.mapID,
+      mapTitle: "title",
+      author: auth.currentUser.uid,
+      url: '',
+      mapItems: [],
+      backgroundColor: 'white',
+      createdAt: Date(),
+    }
+    return newMap;
+  }
 
   useEffect(() => {
     setCanvasAtom(canvasRef);
+    fetchCurrentMap(params.mapID).then(res => {
+      if(res === null){
+        setCanvasAtom(createNewMap());
+      } else{
+        setCurrentMap(res);
+        setCanvasItems(res.mapItems);
+      }
+    })
   }, [])
 
   return (

--- a/src/db/map.js
+++ b/src/db/map.js
@@ -1,5 +1,5 @@
 import { async } from "@firebase/util";
-import { collection, deleteDoc, doc, getDocs, query, setDoc, where } from "firebase/firestore";
+import { collection, deleteDoc, doc, getDocs, getDoc, query, setDoc, where } from "firebase/firestore";
 import { db } from "../client/firebase";
 
 export const postMap = (map) => {
@@ -24,4 +24,15 @@ export const getMaps = async (uid) => {
 
 export const deleteMap = async (mapID) => {
   await deleteDoc(doc(db, "maps", mapID));
+}
+
+export const fetchCurrentMap = async (mapID) => {
+  const docRef = doc(db, "maps", mapID);
+  const docSnap = await getDoc(docRef);
+
+  if (docSnap.exists()) {
+    return docSnap.data();
+  } else {
+    return null;
+  }
 }


### PR DESCRIPTION
#62 
### 実装
index.jsxのuseEffectでurlの値を使ってMapを取得。それをcurrentMapに設定
新規作成の場合は新しいMapを作成し全てからの状態から始める

### 問題点
userがurlを変更してアクセスした場合も、新規マップとして作成ができてしまう。
そうなると、同じmapIDを持ったMapが二つ保存されてしまう可能性(極めて低いけど)がある。

解決策としては、
1, CreateMapをgalleryで押したときにdatabaseに新規マップを追加する、そしてdatabaseにないmapIDを持ったurlではアクセスできないようにする
2, 新規マップを作っているときにリロードした際は、すべての変更を破棄し、galleryページに戻るようにする。(どちらにせよ一から作り直すのでgalleryに飛ばす)

MTGで上記のことを決めたいです