### PR TITLE
autofocus on input in save-map-title modal

### DIFF
--- a/src/components/CreateComponent/Buttons.jsx
+++ b/src/components/CreateComponent/Buttons.jsx
@@ -1,5 +1,5 @@
 import { useAtom, useSetAtom } from "jotai";
-import React, { useState, useEffect } from "react";
+import React, { useState, useLayoutEffect } from "react";
 import { modalDispStatusAtom } from "../../atoms/ComponentAtom";
 import { bgColorSettingAtom, canvasItemsAtom } from "../../atoms/ComponentAtom";
 
@@ -25,13 +25,13 @@ const Buttons = () => {
         }
     }
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         controlSaveButtonClass();
     }, [canvasItems]);
 
     return (
         <div className="m-0 p-0 h-12">
-             
+
             <div className="flex gap-4">
                 <div className="w-5/12">
                     <button
@@ -56,7 +56,7 @@ const Buttons = () => {
                         onClick={() => {
                             setIsColorSetting(!isColorSetting)
                         }}
-                        style={{background: "linear-gradient(60deg,#ffa07a, #ee82ee, #add8e6, #00ffff, #7fffd4,#ffff00, #ffa500)"}}
+                        style={{ background: "linear-gradient(60deg,#ffa07a, #ee82ee, #add8e6, #00ffff, #7fffd4,#ffff00, #ffa500)" }}
                     >
                     </button>
                 </div>

--- a/src/components/CreateComponent/index.jsx
+++ b/src/components/CreateComponent/index.jsx
@@ -11,6 +11,8 @@ import { fetchCurrentMap } from "../../db/map";
 import { currentMapAtom } from "../../atoms/CurrentMapAtom";
 import { auth } from "../../client/firebase";
 
+import { modalDispStatusAtom } from "../../atoms/ComponentAtom";
+
 const CreateComponent = () => {
   const WrappedCanvasArea = forwardRef(CanvasArea);
   const canvasRef = useRef();
@@ -18,6 +20,7 @@ const CreateComponent = () => {
   const params = useParams();
   const [currentMap, setCurrentMap] = useAtom(currentMapAtom);
   const [canvasItems, setCanvasItems] = useAtom(canvasItemsAtom);
+  const modalDisplay = useAtomValue(modalDispStatusAtom);
 
   const createNewMap = () => {
     const newMap = {
@@ -35,16 +38,16 @@ const CreateComponent = () => {
   useEffect(() => {
     setCanvasAtom(canvasRef);
     fetchCurrentMap(params.mapID).then(res => {
-      if(res === null){
+      if (res === null) {
         setCurrentMap(createNewMap());
-      } else{
+      } else {
         setCurrentMap(res);
         setCanvasItems(res.mapItems);
       }
     })
   }, [])
 
-  if(!currentMap){
+  if (!currentMap) {
     return <div>loading</div>
   }
 
@@ -52,7 +55,7 @@ const CreateComponent = () => {
     <div className="flex gap-x-4">
       <WrappedCanvasArea ref={canvasRef} />
       <Sidebar />
-      <SaveMapModal />
+      {modalDisplay !== "hidden" && <SaveMapModal />}
     </div>
   );
 };

--- a/src/modals/SaveMapModal.jsx
+++ b/src/modals/SaveMapModal.jsx
@@ -1,11 +1,11 @@
 import React, { useState } from "react";
-import { useAtom } from "jotai";
+import { useAtom, useSetAtom } from "jotai";
 import { modalDispStatusAtom } from "../atoms/ComponentAtom";
 import { currentMapAtom } from "../atoms/CurrentMapAtom";
 import { useSave } from "../hooks/useSave";
 
 const SaveMapModal = () => {
-    const [modalDisplay, setModalDisplay] = useAtom(modalDispStatusAtom);
+    const setModalDisplay = useSetAtom(modalDispStatusAtom);
     const [currentMap, setCurrentMap] = useAtom(currentMapAtom);
     const [mapTitle, setMapTitle] = useState(currentMap.mapTitle);
     const { saveMap } = useSave();
@@ -28,7 +28,7 @@ const SaveMapModal = () => {
     }
 
     return (
-        <div id="model-wrapper" className={`${modalDisplay} h-screen w-screen bg-slate-700/50 fixed left-0 top-0 flex justify-center items-center`}>
+        <div id="model-wrapper" className="h-screen w-screen bg-slate-700/50 fixed left-0 top-0 flex justify-center items-center">
             <div id="save-map-modal" tabindex="-1" aria-hidden="true"
                 className="w-1/3"
             >
@@ -58,6 +58,7 @@ const SaveMapModal = () => {
                                     <input
                                         type="text"
                                         name="map-name"
+                                        autoFocus={true}
                                         onChange={onInputChange}
                                         value={mapTitle}
                                         minlength="1"


### PR DESCRIPTION
Issue #80 

## 目的
- SaveMapTitleModalを開いた時にInputにAutoFocusする

## 実装内容
- inputにautoFocus={true}を追加
- 今までは常にSaveMapModalコンポーネントを読み込んでいて、hiddenクラスで表示を制御していたが、今回からmodalDispStatusAtomがhiddenじゃない時だけレンダリングするように変更（autoFocusがレンダリング時に機能するため）
- 上記の変更でSaveボタンがちらつくようになったので、Buttons.jsxのuseEffectをuseLayoutEffectに変更

## 参考
useEffectのちらつきを無くしたいときの対処法【useLayoutEffect】
https://zenn.dev/syu/articles/6b96e34535b33e