### PR TITLE
無限レンダリングを防ぐのと選択中のアイテムの解除

### DIFF
--- a/src/components/CreateComponent/CanvasArea.jsx
+++ b/src/components/CreateComponent/CanvasArea.jsx
@@ -65,7 +65,7 @@ const CanvasArea = ({ }, canvasRef) => {
 
     const handleClick = (e) => {
         setIsBgColorSetting(false);
-        if (selectedText && (e.target == stageRef.current || e.target === backgroundRef.current)){
+        if (selectedText && (e.target === backgroundRef.current || e.target === stageRef.current.children[0].children[0])){
             cancelSelectedText();
         }
     }
@@ -119,8 +119,7 @@ const CanvasArea = ({ }, canvasRef) => {
     }, [isUnderline])
 
     const checkDeselect = (e) => {
-        // const clickedOnEmpty = e.target === e.target.getStage();
-        const clickedOnEmpty = e.target === backgroundRef.current;
+        const clickedOnEmpty = e.target === backgroundRef.current || e.target === stageRef.current.children[0].children[0];
         if (clickedOnEmpty) {
             selectImage(null);
         }
@@ -186,9 +185,6 @@ const CanvasArea = ({ }, canvasRef) => {
         currentMap.backgroundColor = bgColor;
     },[bgColor])
 
-    useEffect(() => {
-        console.log('bg')
-    }, [backgroundImage])
     
     return (
         <div ref={canvasRef}>


### PR DESCRIPTION
#105

backgroundImageが設定されていない時にアイテムの選択が解除されないことが原因で無限レンダリングが起きてた
